### PR TITLE
Multi Fixes for The FastAPI_mongodb

### DIFF
--- a/fastapi_mongodb/helpers.py
+++ b/fastapi_mongodb/helpers.py
@@ -127,8 +127,8 @@ class BaseProfiler:
     ):
         self.number_frames = number_frames
         self.clear_traces = clear_traces
-        self.include_files = include_files if include_files else []
-        self.exclude_files = exclude_files if exclude_files else []
+        self.include_files = include_files or []
+        self.exclude_files = exclude_files or []
         self.show_memory = show_memory
         self._start_time = None
         self._end_time = None
@@ -179,9 +179,11 @@ class BaseProfiler:
     def _get_trace_malloc_filters(
         self,
     ) -> list[typing.Union[tracemalloc.Filter, tracemalloc.DomainFilter]]:
-        filters = []
-        for file_name in self.include_files:
-            filters.append(tracemalloc.Filter(inclusive=True, filename_pattern=file_name))
+        filters = [
+            tracemalloc.Filter(inclusive=True, filename_pattern=file_name)
+            for file_name in self.include_files
+        ]
+
         for file_name in self.exclude_files:
             filters.append(tracemalloc.Filter(inclusive=False, filename_pattern=file_name))
         return filters

--- a/fastapi_mongodb/repositories.py
+++ b/fastapi_mongodb/repositories.py
@@ -54,7 +54,7 @@ class BaseRepository:
         convert_to = repository_config.convert_to or self.repository_config.convert_to
         if repository_config.convert:
             return (convert_to.from_db(data=result) async for result in results_cursor)
-        return (item async for item in results_cursor)
+        return iter(results_cursor)
 
     def _raise_not_found(self, *, result, repository_config: BaseRepositoryConfig = None):
         """raise an error if result is None"""

--- a/fastapi_mongodb/tests/test_db.py
+++ b/fastapi_mongodb/tests/test_db.py
@@ -196,11 +196,7 @@ class TestTopologyLogger(AsyncTestCase):
         self.debug_mock.assert_called_once_with(f"Topology with id {self.event.topology_id} opened")
 
     def test_description_changed(self):
-        self.event.new_description.has_writable_server.return_value = False
-        self.event.new_description.has_readable_server.return_value = False
-
-        self.logger.description_changed(event=self.event)
-
+        self._extracted_from_test_description_changed_not_changed_2(False)
         self.debug_mock.assert_has_calls(
             calls=[
                 mock_call(f"Topology description updated for topology id {self.event.topology_id}"),
@@ -218,14 +214,15 @@ class TestTopologyLogger(AsyncTestCase):
         expected_mock = MagicMock()
         self.event.previous_description.topology_type = expected_mock
         self.event.new_description.topology_type = expected_mock
-        self.event.new_description.has_writable_server.return_value = True
-        self.event.new_description.has_readable_server.return_value = True
-
-        self.logger.description_changed(event=self.event)
-
+        self._extracted_from_test_description_changed_not_changed_2(True)
         self.debug_mock.assert_called_once_with(
             f"Topology description updated for topology id {self.event.topology_id}"
         )
+
+    def _extracted_from_test_description_changed_not_changed_2(self, arg0):
+        self.event.new_description.has_writable_server.return_value = arg0
+        self.event.new_description.has_readable_server.return_value = arg0
+        self.logger.description_changed(event=self.event)
 
     def test_closed(self):
         self.logger.closed(event=self.event)

--- a/fastapi_mongodb/tests/test_pagination.py
+++ b/fastapi_mongodb/tests/test_pagination.py
@@ -13,9 +13,9 @@ class TestLimitOffsetPagination(AsyncTestCase):
 
         result = self.pagination_instance(limit=default_limit, offset=default_offset)
 
-        self.assertIsInstance(result, Paginator)
-        self.assertEqual(default_limit, result.limit)
-        self.assertEqual(default_offset, result.skip)
+        self._extracted_from_test__call__custom_7(
+            result, default_limit, default_offset
+        )
 
     def test__call__custom(self):
         custom_limit = self.faker.pyint(
@@ -26,6 +26,9 @@ class TestLimitOffsetPagination(AsyncTestCase):
 
         result = self.pagination_instance(offset=custom_offset, limit=custom_limit)
 
+        self._extracted_from_test__call__custom_7(result, custom_limit, custom_offset)
+
+    def _extracted_from_test__call__custom_7(self, result, arg1, arg2):
         self.assertIsInstance(result, Paginator)
-        self.assertEqual(custom_limit, result.limit)
-        self.assertEqual(custom_offset, result.skip)
+        self.assertEqual(arg1, result.limit)
+        self.assertEqual(arg2, result.skip)

--- a/fastapi_mongodb/tests/test_repositories.py
+++ b/fastapi_mongodb/tests/test_repositories.py
@@ -99,17 +99,17 @@ class TestBaseRepository(AsyncTestCase):
 
     def test__raise_not_found(self):
         result_dict = self.faker.pydict()
-        repository_config_mock = MagicMock(raise_not_found=True)
-
-        result = self.repository_class._raise_not_found(result=result_dict, repository_config=repository_config_mock)
-
-        self.assertIsNone(result)
+        self._extracted_from_test__raise_not_found_disabled_3(True, result_dict)
 
     def test__raise_not_found_disabled(self):
         query_result = None
-        repository_config_mock = MagicMock(raise_not_found=False)
+        self._extracted_from_test__raise_not_found_disabled_3(False, query_result)
 
-        result = self.repository_class._raise_not_found(result=query_result, repository_config=repository_config_mock)
+    def _extracted_from_test__raise_not_found_disabled_3(self, raise_not_found, result):
+        repository_config_mock = MagicMock(raise_not_found=raise_not_found)
+        result = self.repository_class._raise_not_found(
+            result=result, repository_config=repository_config_mock
+        )
 
         self.assertIsNone(result)
 
@@ -330,9 +330,11 @@ class TestBaseRepository(AsyncTestCase):
 
     async def test_count_documents(self):
         counter = self.faker.pyint(min_value=2, max_value=10)
-        documents = []
-        for _ in range(counter):
-            documents.append({"_id": ObjectId(), self.faker.pystr(): self.faker.pystr()})
+        documents = [
+            {"_id": ObjectId(), self.faker.pystr(): self.faker.pystr()}
+            for _ in range(counter)
+        ]
+
         await self.repository_class.insert_many(documents=documents)
 
         result = await self.repository_class.count_documents(query={})
@@ -341,9 +343,11 @@ class TestBaseRepository(AsyncTestCase):
 
     async def test_estimated_document_count(self):
         counter = self.faker.pyint(min_value=2, max_value=10)
-        documents = []
-        for _ in range(counter):
-            documents.append({"_id": ObjectId(), self.faker.pystr(): self.faker.pystr()})
+        documents = [
+            {"_id": ObjectId(), self.faker.pystr(): self.faker.pystr()}
+            for _ in range(counter)
+        ]
+
         await self.repository_class.insert_many(documents=documents)
 
         result = await self.repository_class.estimated_document_count()


### PR DESCRIPTION
- An identity generator can be replaced directly with the collection in this Function `BaseRepository.convert_many_results`.
- Replaces `if` expressions that compare to the target with `or` in this Function `BaseProfiler.__init__`.
- Converts a `for` loop into a list comprehension in this Function `BaseProfiler._get_trace_malloc_filters`.